### PR TITLE
헤더 링크추가 (커뮤니티, 이용가이드), 파비콘 적용 일부 됨. 전역은 안됨

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -43,7 +43,9 @@
         </li>
         <li><a href="/booking/booking.html" class="nav_text">공간예약</a></li>
         <li class="line">|</li>
-        <li><a href="#" class="nav_text">커뮤니티</a></li>
+        <li>
+          <a href="/community/community.html" class="nav_text">커뮤니티</a>
+        </li>
         <li>
           <a href="/complete_project/complete_project.html" class="nav_text"
             >완성 프로젝트</a
@@ -53,7 +55,12 @@
       </ul>
       <div class="desc_text flex_box_row">
         처음이신가요? &nbsp
-        <span class="desc_point_text">이용가이드</span>
+
+        <span class="desc_point_text">
+          <a href="/guide/guide.html" class="desc_point_text"
+            >이용가이드</a
+          ></span
+        >
         <img src="/src/img/right.png" alt="right" />
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SeSAC PIUM</title>
+    <title>PIUM</title>
     <link rel="icon" type="image/png" href="./src/img/favicon.ico" />
     <link rel="stylesheet" href="./common/global_style.css" />
     <link rel="stylesheet" href="./main/index.css" />


### PR DESCRIPTION
파비콘 적용(단, 전역에는 해당하지 않음. header.html에 파비콘 링크 걸었는데 왜 안되는지..?)
![image](https://github.com/lkf6214/SeSAC-PIUM/assets/107837292/b3e5b2d8-429a-43c2-8ef6-8e1b905b58e8)

헤더 nav에 링크 연결(new 커뮤니티, 이용가이드)
![image](https://github.com/lkf6214/SeSAC-PIUM/assets/107837292/1e064a07-a7b5-4ae9-b981-42123875f3d8)

mainpage 모달창 block상태임.
![image](https://github.com/lkf6214/SeSAC-PIUM/assets/107837292/804b5eaf-08bb-4407-8b89-666a3314d696)

index.html prettier 오류 발견
![image](https://github.com/lkf6214/SeSAC-PIUM/assets/107837292/d2600716-ad73-43ff-b8d6-207f66e4cbe5)
